### PR TITLE
better messages for two errors

### DIFF
--- a/R/resamp_define.R
+++ b/R/resamp_define.R
@@ -29,8 +29,15 @@ define_psa <- function(...,
   
   list_input <- lapply(
     .dots,
-    function(x) eval(attr(stats::terms(x), "variables")[[3]])
-  )
+    function(x) {
+      terms <- attr(stats::terms(x), "variables")
+      if(length(terms) < 3){
+        stop(paste("there is a problem in the definition of the psa",
+                   "distribution for parameter",
+                   as.character(terms[2])))
+      }
+      eval(terms[[3]])
+  })
   
   list_qdist <- unlist(
     list_input,

--- a/R/tabular_input.R
+++ b/R/tabular_input.R
@@ -280,7 +280,15 @@ create_model_list_from_tabular <- function(ref, df_env = globalenv()) {
   
   tm_info <- tm_info[names(state_info)]
   
-  if (options()$heemod.verbose) message("*** Defining models...")
+  undefined <- subset(do.call("rbind", tm_info), is.na(prob))
+  if(nrow(undefined) > 0){
+    rownames(undefined) <- NULL
+    print(undefined)
+    stop("some probabilities in the transition matrix are undefined (see above)")
+  }
+  
+  
+if (options()$heemod.verbose) message("*** Defining models...")
   models <- lapply(
     seq_along(state_info),
     function(i) {

--- a/inst/tabular/test/REFERENCE_1probmissing.csv
+++ b/inst/tabular/test/REFERENCE_1probmissing.csv
@@ -1,0 +1,8 @@
+data,file,.comment,.comment2
+state,THR_test_states.csv,list of states and their costs and effects,
+tm,THR_test_transition_probs_1missing.csv,transition probabilities,
+parameters,THR_parameters.csv,parameters of the models,
+,,,
+data,input_dataframes,folder that stores the dataframes to be input,input_dataframes
+output,output,folder to store outputs,
+options,THR_options.csv,model options,

--- a/inst/tabular/test/THR_test_transition_probs_1missing.csv
+++ b/inst/tabular/test/THR_test_transition_probs_1missing.csv
@@ -1,0 +1,13 @@
+.model,from,to,prob
+standard,PrimaryTHR,SuccessfulPrimary,C
+standard,PrimaryTHR,Death,0.02
+standard,SuccessfulPrimary,SuccessfulPrimary,C
+standard,SuccessfulPrimary,RevisionTHR,pHRFailStandard
+new,SuccessfulPrimary,RevisionTHR,pHRFailNew
+standard,SuccessfulPrimary,Death,mr
+standard,RevisionTHR,SuccessfulRevision,
+standard,RevisionTHR,Death,0.02
+standard,SuccessfulRevision,SuccessfulRevision,C
+standard,SuccessfulRevision,RevisionTHR,0.04
+standard,SuccessfulRevision,Death,mr
+standard,Death,Death,1

--- a/tests/testthat/test_probabilistic.R
+++ b/tests/testthat/test_probabilistic.R
@@ -171,6 +171,12 @@ test_that(
       )
     )
     expect_error(
+      define_psa(
+        x ~ normal(60, 10),
+        y ~ 0),
+      "there is a problem in the definition of the psa distribution for parameter y"
+      )
+    expect_error(
       define_correlation(age_init, cost_init, .4, .5)
     )
     expect_error(

--- a/tests/testthat/test_tabular_input.R
+++ b/tests/testthat/test_tabular_input.R
@@ -132,6 +132,13 @@ test_that(
         "REFERENCE.csv"),
       "newzzz"
     )
+    expect_error(
+      heemod:::gather_model_info(
+        system.file("tabular/test", package = "heemod"),
+        "REFERENCE_1probmissing.csv"),
+      "some probabilities in the transition matrix are undefined"
+    )
+    
     dup_state <- structure(list(
       .model = c("standard", "standard", "standard", 
                  "standard", "standard"),


### PR DESCRIPTION
Antoine - I found another one just after you sent the branch.

1st error:   if you leave out a probability in the tm input file (that is, you put model, to and from, but leave "prob" blank), it used to give a confusing error; now it tells you where the problem is.  And a corresponding test.

2nd error:  if a psa distribution is accidentally mis-specified (for example, if you put a number in instead of a formula), now returns a more informative error message.   And added a corresponding test.

Regards,
Matt