### PR TITLE
Update matrix_eval.R error message

### DIFF
--- a/R/matrix_eval.R
+++ b/R/matrix_eval.R
@@ -32,7 +32,7 @@ check_matrix <- function(x) {
       paste(sprintf(
         "cycle: %s, state: %s",
         problem_rows[,1],
-        get_state_names(x)[problem_rows[,2]]),
+        problem_rows[,2]),
         collapse = "\n")
     ))
     


### PR DESCRIPTION
Antoine - the error message I've modified here after your excellent change before - I will try to remember how you did that - is simply to fix a typo.   In your modification you fixed problem_rows to already have the state names in the second row, but then left a second conversion in the error message, which leads to getting NAs printed in the actual error message.   This fixes that.
Regards,
Matt