### PR TITLE
read in local functions (tabular_input)

### DIFF
--- a/R/tabular_input.R
+++ b/R/tabular_input.R
@@ -115,8 +115,13 @@ gather_model_info <- function(base_dir, ref_file) {
 
   if("functions" %in% ref$data){
     if(options()$heemod.verbose) message("** Reading functions...")
-    for(this_file in list.files(ref$full_file[ref$data == "functions"],
-                                full.names = TRUE)){
+    function_dir <- ref$full_file[ref$data == "functions"]
+    function_list <- list.files(function_dir, full.names = TRUE)
+    if(length(function_list) == 0)
+      stop("no functions in 'functions' directory: ", 
+           ref$file[ref$data == "functions"])
+                                                              
+    for(this_file in function_list){
       source(this_file, echo = FALSE, local = TRUE)
     }
   }

--- a/R/tabular_input.R
+++ b/R/tabular_input.R
@@ -112,7 +112,15 @@ gather_model_info <- function(base_dir, ref_file) {
       df_env
     )
   }
-  
+
+  if("functions" %in% ref$data){
+    if(options()$heemod.verbose) message("** Reading functions...")
+    for(this_file in list.files(ref$full_file[ref$data == "functions"],
+                                full.names = TRUE)){
+      source(this_file, echo = FALSE, local = TRUE)
+    }
+  }
+
   ## note - the environment df_env gets included directly
   ##   into param_info, so anything that will load anything
   ##   into that environment needs to come before this statement

--- a/tests/testthat/test_tabular_input.R
+++ b/tests/testthat/test_tabular_input.R
@@ -122,6 +122,36 @@ test_that("can read multinomial parameters from file",
 )
 
 test_that(
+  "Bad spec file input is caught.", {
+    expect_error(
+      heemod:::gather_model_info(
+        system.file("tabular/test", package = "heemod"),
+        "bad_REFERENCE.csv")
+    )
+    expect_error(
+      heemod:::gather_model_info(
+        system.file("tabular/test/test_diff_mod_name", package = "heemod"),
+        "REFERENCE.csv"),
+      "newzzz"
+    )
+    expect_error(
+      capture.output(
+        heemod:::gather_model_info(
+          system.file("tabular/test", package = "heemod"),
+          "REFERENCE_1probmissing.csv")
+        ),
+      "Undefined probabilities"
+    )
+    expect_error(
+      heemod:::gather_model_info(
+        system.file("tabular/test", package = "heemod"),
+        "REFERENCE_missingfunctions.csv"),
+      "no functions in 'functions' directory: notpresent"
+    )
+  }
+)
+
+test_that(
   "Bad state file input is caught.", {
     expect_error(
       heemod:::create_states_from_tabular(NULL),
@@ -141,23 +171,6 @@ test_that(
       fixed = TRUE
     )
     
-    expect_error(
-      heemod:::gather_model_info(
-        system.file("tabular/test", package = "heemod"),
-        "bad_REFERENCE.csv")
-    )
-    expect_error(
-      heemod:::gather_model_info(
-        system.file("tabular/test/test_diff_mod_name", package = "heemod"),
-        "REFERENCE.csv"),
-      "newzzz"
-    )
-    expect_error(
-      heemod:::gather_model_info(
-        system.file("tabular/test", package = "heemod"),
-        "REFERENCE_1probmissing.csv"),
-      "Undefined probabilities"
-    )
     
     dup_state <- structure(list(
       .model = c("standard", "standard", "standard", 
@@ -212,6 +225,11 @@ test_that(
     expect_error(
       heemod:::create_states_from_tabular(mult_disc_state)
     )
+  }
+)
+ 
+test_that(
+  "Bad transmission matrix input is caught.", {
     
     bad_tm <- structure(list(
       .model = c("standard", "standard", "standard", 
@@ -239,7 +257,11 @@ test_that(
           "SuccessfulRevisionzzz")
       )
     )
+  }
+)
     
+test_that(
+  "Bad parameter file input is caught.", {
     pb_par <- structure(list(
       parameter = c("lngamma", "gamma"),
       value = c("0.3740968", 
@@ -309,7 +331,12 @@ test_that(
     expect_error(
       heemod:::create_parameters_from_tabular(pb_par)
     )
-    
+  }
+)
+
+test_that(
+    "other bad input is caught.", {
+        
     opt_pb <- structure(list(
       option = c("cost", "effect", "method", "method", 
                  "n"),
@@ -363,7 +390,7 @@ test_that(
     )
     
     expect_error(
-      create_model_from_tabular(states1, NULL, NULL, new.env())
+        create_model_from_tabular(states1, NULL, NULL, new.env())
     )
   }
 )

--- a/vignettes/h-tabular.Rmd
+++ b/vignettes/h-tabular.Rmd
@@ -46,6 +46,8 @@ Optionally, the following rows can be provided:
   5. `demographics`: file describing of the population to run the models on.
   6. `data`: a *directory* containing additional tables to be loaded; these can be `.csv`, `.xls` or `.xlsx`.
   7. `output`: a *directory* to save the output graphics.  
+  8.  `functions`: a *directory* in which functions used in your analysis can
+      be placed, and will be sourced into the local environment when you run the model.  They will not persist in the global environment.
 
 ```{r echo = FALSE}
 heemod:::read_file(system.file("tabular/thr/REFERENCE.csv", package = "heemod")) %>% 


### PR DESCRIPTION
I've run across a case in which there's a small function useful in the context of a particular model, but not worth adding to the package even as part of a set of convenience functions.  So I propose modifying tabular_input to allow for an additional element, "functions", whose value is a directory where you can put R files that will get sourced.   They are sourced into the local environment when running the model, and don't persist in the global environment.   (I checked.)   

Also added a test to make sure the above throws an error if you give it an improper "functions" element, eliminated output in one of the existing tests using capture.output, and broke up the tests for tabular_input into more granular groups.

I also added a note about this to the "h-tabular" vignette.