### PR TITLE
improve warning in look_up

### DIFF
--- a/R/look_up.R
+++ b/R/look_up.R
@@ -114,8 +114,14 @@ look_up <- function(data, ..., bin = FALSE, value = "value") {
   }
   
   if (any(is.na(res))) {
-    warning("Some values were not found, returning missing data.")
+    warning("Some values were not found, returning missing data:\n",
+            "names of the data.frame being looked up in: ", 
+            paste(names(data), collapse = ", "),
+            "\n",
+            "arguments to look_up:",
+            paste(names(list_specs), "=", unlist(list_specs), collapse = ", ")
+    )
   }
-  
+   
   res
 }

--- a/R/look_up.R
+++ b/R/look_up.R
@@ -115,11 +115,9 @@ look_up <- function(data, ..., bin = FALSE, value = "value") {
   
   if (any(is.na(res))) {
     warning("Some values were not found, returning missing data:\n",
-            "names of the data.frame being looked up in: ", 
-            paste(names(data), collapse = ", "),
-            "\n",
-            "arguments to look_up:",
-            paste(names(list_specs), "=", unlist(list_specs), collapse = ", ")
+            "arguments to look_up: ",
+            paste(names(list_specs), "=", unlist(list_specs), collapse = ", "),
+                  ", value = ", value
     )
   }
    


### PR DESCRIPTION
If any NA results are returned, the current version just notes NA results are being returned, which doesn't help find which look_up statement is causing the problem.   New warning message returns the names of the data object being looked up in (since I don't think the name of the data object itself is accessible from within the call - the call has already had the data.frame substituted in -- it's not even present in the full call stack I can get from within the function), as well as the selection arguments passed in.   This makes it reasonably easy to find the offending call.

(I'm not sure now whether I should be submitting to devel or master - please let me know.)