### PR TITLE
improve state printing for multi-line values

### DIFF
--- a/R/states_print.R
+++ b/R/states_print.R
@@ -5,7 +5,7 @@ print.state <- function(x, ...) {
     length(x), plur(length(x))))
   
   nv <- names(x)
-  ex <- unlist(lapply(x, function(y) deparse(y$expr)))
+  ex <- lapply(x, function(y) paste(deparse(y$expr), collapse = "\n"))
   
   cat(paste(nv, ex, sep = " = "), sep = "\n") 
 }


### PR DESCRIPTION
In the current code, if the definition of a state value stretches over more than one line, deparse breaks it up into multiple lines; the unlist in the current code then returns more lines than there are states.   Then you end up with many repeated names, and difficult to interpret output.   This takes care of it, while remaining identical in the case where all state values are defined in a single line.