### PR TITLE
Don't subset global `.data` object

### DIFF
--- a/R/sensitivity_print.R
+++ b/R/sensitivity_print.R
@@ -113,7 +113,7 @@ plot.dsa <- function(x, type = c("simple", "difference"),
           .deffect_ref = .data$.deffect,
           .icer_ref = .data$.icer
         ),
-      by = .data$.strategy_names
+      by = ".strategy_names"
     ) %>% 
     dplyr::mutate(
       .col_cost = ifelse(.data$.cost > .data$.cost_ref, ">",


### PR DESCRIPTION
`rlang::.data` is subsetted because by` is not a data-masked argument. This will cause an error in the next rlang version which we plan to release within the month.